### PR TITLE
[update,fix] dreamerv3

### DIFF
--- a/dm3.py
+++ b/dm3.py
@@ -940,7 +940,7 @@ def behavior_learning(posteriors_: Tensor, deterministics_: Tensor):
         states = []
         deterministics = []
         for t in range(args.horizon):
-            action = actor(state, deterministic).rsample()
+            action = actor(state.detach(), deterministic.detach()).rsample()  # detach help speed up about 10%
             deterministic = recurrent_model(state, action, deterministic)
             state_dist, state_logits = transition_model(deterministic)
             state = state_dist.rsample().view(-1, args.stochastic_size)

--- a/rvrl/utils/timer.py
+++ b/rvrl/utils/timer.py
@@ -20,11 +20,11 @@ class timer(ContextDecorator):
     timers: dict[str, Metric] = {}
     _start_time: float | None = None
 
-    def __init__(self, name: str, metric: type[Metric] | None = None, **kwargs) -> None:
+    def __init__(self, name: str, metric: type[Metric] = SumMetric, **kwargs) -> None:
         """Add timer to dict of timers after initialization"""
         self.name = name
         if not timer.disabled and self.name is not None and self.name not in self.timers.keys():
-            self.timers.setdefault(self.name, metric(**kwargs) if metric is not None else SumMetric(**kwargs))
+            self.timers.setdefault(self.name, metric(**kwargs))
 
     def start(self) -> None:
         """Start a new timer"""


### PR DESCRIPTION
1. Implement reinforce actor gradient, though it doesn't work for dmc tasks for now. dreamerv3-torch doesn't work either. Original dreamerv3 use reinforce and works, need to find out why in the future.
2. Detach the states passed to actor network. This aligns dreamerv3-torch, sheeprl, and original dreamerv3's implementation. The reward curve doesn't change much on dmc walker-run. The overall training time reduced ~10%.
3. Update timer class and add more fine-grained timing